### PR TITLE
specify branch for libfranka-common

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "common"]
 	path = common
 	url = https://github.com/tingelst/libfranka-common.git
+	branch = fr3-develop


### PR DESCRIPTION
Currently the submodule branch isn't specified which leads to the following build error as the default branch is pulled:

```
-- Configuring done
-- Generating done
-- Build files have been written to: /home/peter/Code/libfranka/build
[  1%] Building CXX object CMakeFiles/franka.dir/src/active_control.cpp.o
In file included from /home/peter/Code/libfranka/src/active_control.cpp:9:
/home/peter/Code/libfranka/src/robot_impl.h: In member function ‘std::enable_if_t<(! std::is_base_of<research_interface::robot::GetterSetterCommandBase<T, T::kCommand>, T>::value)> franka::Robot::Impl::handleCommandResponse(const typename T::Response&) const [with T = research_interface::robot::Move; std::enable_if_t<(! std::is_base_of<research_interface::robot::GetterSetterCommandBase<T, T::kCommand>, T>::value)> = void; typename T::Response = research_interface::robot::ResponseBase<research_interface::robot::Move>]’:
/home/peter/Code/libfranka/src/robot_impl.h:256:51: error: ‘kPreemptedDueToActivatedSafetyFunctions’ is not a member of ‘research_interface::robot::Move::Status’
  256 |     case research_interface::robot::Move::Status::kPreemptedDueToActivatedSafetyFunctions:
      |                                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
gmake[2]: *** [CMakeFiles/franka.dir/build.make:76: CMakeFiles/franka.dir/src/active_control.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:160: CMakeFiles/franka.dir/all] Error 2
gmake: *** [Makefile:156: all] Error 2
```

This pull request fixes this so others can leverage the backport work that @tingelst kindly open-sourced.